### PR TITLE
表示サイズを小さくした時にレイアウト崩れがある問題

### DIFF
--- a/public/stylesheets/archweb.css
+++ b/public/stylesheets/archweb.css
@@ -916,8 +916,11 @@ table td.country {
 
 .arch-bio-entry {
     width: 75%;
-    min-width: 640px;
+    /* min-width: 640px; */
+    min-width: auto;
     margin: 0 auto;
+    /* mobile */
+    word-break: break-all;
 }
 
     .arch-bio-entry td.pic {


### PR DESCRIPTION
[https://www.archlinuxjp.org](https://www.archlinuxjp.org)で表示サイズを小さくした時、例えば、以下のようなページでレイアウトが崩れてしまいます。

https://www.archlinuxjp.org/people/

この問題を解決するには、`width-min`を指定しないことと、`word-break`で文字の区切りを指定することで回避できると思われます。
