### PR TITLE
fix: width over the tbody

### DIFF
--- a/public/stylesheets/mobile.css
+++ b/public/stylesheets/mobile.css
@@ -71,3 +71,8 @@ body {
     max-width: 90%;
     height: auto;
 }
+
+tbody {
+    word-break: break-all;
+    /* white-space: inherit; */
+}


### PR DESCRIPTION
以下のページで幅を一定以上とれないと、`tbody`が一部はみ出る問題について

https://wiki.archlinuxjp.org/index.php/%E3%83%98%E3%83%AB%E3%83%97:%E7%B7%A8%E9%9B%86

例えば、タブレットNexus7での閲覧でレイアウト崩れが確認できます。

問題の解決にはもっとスマートなやり方があるかもしれませんので、問題提起として、一旦、`Pull Req`を送ります。
