### PR TITLE
Google検索の検索結果にて検索フォームを表示する(Wiki検索)

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -24,6 +24,17 @@ html(lang="ja")
 		link(rel="apple-touch-icon", sizes="114x114", href="/images/apple-touch-icon-114x114.png")
 		link(rel="apple-touch-icon", sizes="144x144", href="/images/apple-touch-icon-144x144.png")
 		meta(name="theme-color", content="#08C")
+		script(type="application/ld+json").
+			{
+				"@context": "http://schema.org",
+				"@type": "WebSite",
+				"url": "https://www.archlinuxjp.org/",
+				"potentialAction": {
+					"@type": "SearchAction",
+					"target": "https://wiki.archlinuxjp.org/index.php?search={search_term}",
+					"query-input": "required name=search_term"
+				}
+			}
 	body
 		div#archnavbar(class=selected)
 			- if(xmas){


### PR DESCRIPTION
これは、Google検索の検索結果にて検索フォームを表示する実装です。表示されるかどうかはGoogleの判断によりますが、表示を促すことができます。

http://schema.org

本家 archlinux.org ではパッケージを検索するようですが、こちらではWikiを検索するようにしています。

> archlinux.org

``` html
    <script type="application/ld+json">
    {
       "@context": "http://schema.org",
       "@type": "WebSite",
       "url": "https://www.archlinux.org/",
       "potentialAction": {
         "@type": "SearchAction",
         "target": "https://www.archlinux.org/packages/?q={search_term}",
         "query-input": "required name=search_term"
       }
    }
    </script>
```

> jp

``` html
-  "target": "https://www.archlinux.org/packages/?q={search_term}",
+ "target": "https://wiki.archlinuxjp.org/index.php?search={search_term}"
```

私ではどちらが良いか判断できませんので、個人的な好みによって決定しています。したがって、適時、適切な形に変更してもらって全然構いません。また、この実装自体が一つのアイディアとしての提案なので、その他の部分についても同様です。適時、適切な形での変更をしてもらって構いません。
