### PR TITLE
ブラウザのアドレスバーにてTab検索を追加する(パッケージ検索)

### DIFF
--- a/public/static/opensearch.xml
+++ b/public/static/opensearch.xml
@@ -1,7 +1,8 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
 <Url type="text/html" method="get" template="https://www.archlinuxjp.org/packages/?q={searchTerms}"/>
 <InputEncoding>UTF-8</InputEncoding>
-<Image width="16" height="16">https://www.archlinuxjp.org/images/favicon.ico</Image>
+<Image height="16" width="16" type="image/x-icon">https://www.archlinuxjp.org/images/favicon.ico</Image>
+<Image height="64" width="64" type="image/png">https://www.archlinuxjp.org/images/archlogo.png</Image>
 <ShortName>Arch Packages</ShortName>
 <Description>Search the Arch Linux package repositories by keyword in package names and descriptions.</Description>
 </OpenSearchDescription>

--- a/public/static/opensearch.xml
+++ b/public/static/opensearch.xml
@@ -1,30 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-	<ShortName>Arch Packages</ShortName>
-	<LongName>Arch Linux Package Repository Search</LongName>
-	<Description>Search the Arch Linux package repositories by keyword in package names and descriptions.</Description>
-	<Tags>linux archlinux package software</Tags>
-	<Image height="16" width="16" type="image/x-icon">https://www.archlinuxjp.org/images/favicon.ico</Image>
-	<Image height="64" width="64" type="image/png">https://www.archlinuxjp.org/images/archlogo.png</Image>
-	<Language>ja-jp</Language>
-	<InputEncoding>UTF-8</InputEncoding>
-	<OutputEncoding>UTF-8</OutputEncoding>
-	<Query role="example" searchTerms="initscripts"/>
-	<Url type="text/html" template="https://www.archlinuxjp.org/packages/?q={searchTerms}"/>
-	<Url rel="suggestions" type="application/x-suggestions+json"
-		template="https://www.archlinux.org/opensearch/packages/suggest?q={searchTerms}"/>
-	<Url rel="self" type="application/opensearchdescription+xml"
-		template="https://www.archlinuxjp.org/opensearch.xml"/>
-</OpenSearchDescription>
-<!-- min
-<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-<ShortName>Arch Packages</ShortName>
-<Description>Search Arch Linux</Description>
+<Url type="text/html" method="get" template="https://www.archlinuxjp.org/packages/?q={searchTerms}"/>
 <InputEncoding>UTF-8</InputEncoding>
-<Image height="16" type="image/x-icon" width="16">
-https://www.archlinuxjp.org/images/favicon.ico
-</Image>
-<Url method="get" template="https://www.archlinuxjp.org/packages/?q={searchTerms}" type="text/html"/>
-<moz:SearchForm>https://www.archlinuxjp.org/packages</moz:SearchForm>
+<Image width="16" height="16">https://www.archlinuxjp.org/images/favicon.ico</Image>
+<ShortName>Arch Packages</ShortName>
+<Description>Search the Arch Linux package repositories by keyword in package names and descriptions.</Description>
 </OpenSearchDescription>
--->

--- a/public/static/opensearch.xml
+++ b/public/static/opensearch.xml
@@ -2,7 +2,7 @@
 <Url type="text/html" method="get" template="https://www.archlinuxjp.org/packages/?q={searchTerms}"/>
 <InputEncoding>UTF-8</InputEncoding>
 <Image height="16" width="16" type="image/x-icon">https://www.archlinuxjp.org/images/favicon.ico</Image>
-<Image height="64" width="64" type="image/png">https://www.archlinuxjp.org/images/archlogo.png</Image>
+<Image height="64" width="64" type="image/png">https://www.archlinuxjp.org/images/amplogo.png</Image>
 <ShortName>Arch Packages</ShortName>
 <Description>Search the Arch Linux package repositories by keyword in package names and descriptions.</Description>
 </OpenSearchDescription>

--- a/public/static/opensearch.xml
+++ b/public/static/opensearch.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+	<ShortName>Arch Packages</ShortName>
+	<LongName>Arch Linux Package Repository Search</LongName>
+	<Description>Search the Arch Linux package repositories by keyword in package names and descriptions.</Description>
+	<Tags>linux archlinux package software</Tags>
+	<Image height="16" width="16" type="image/x-icon">https://www.archlinuxjp.org/images/favicon.ico</Image>
+	<Image height="64" width="64" type="image/png">https://www.archlinuxjp.org/images/archlogo.png</Image>
+	<Language>ja-jp</Language>
+	<InputEncoding>UTF-8</InputEncoding>
+	<OutputEncoding>UTF-8</OutputEncoding>
+	<Query role="example" searchTerms="initscripts"/>
+	<Url type="text/html" template="https://www.archlinuxjp.org/packages/?q={searchTerms}"/>
+	<Url rel="suggestions" type="application/x-suggestions+json"
+		template="https://www.archlinux.org/opensearch/packages/suggest?q={searchTerms}"/>
+	<Url rel="self" type="application/opensearchdescription+xml"
+		template="https://www.archlinuxjp.org/opensearch.xml"/>
+</OpenSearchDescription>
+<!-- min
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+<ShortName>Arch Packages</ShortName>
+<Description>Search Arch Linux</Description>
+<InputEncoding>UTF-8</InputEncoding>
+<Image height="16" type="image/x-icon" width="16">
+https://www.archlinuxjp.org/images/favicon.ico
+</Image>
+<Url method="get" template="https://www.archlinuxjp.org/packages/?q={searchTerms}" type="text/html"/>
+<moz:SearchForm>https://www.archlinuxjp.org/packages</moz:SearchForm>
+</OpenSearchDescription>
+-->

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -23,7 +23,7 @@ html(lang="ja")
 		link(rel="apple-touch-icon", sizes="72x72", href="/images/apple-touch-icon-72x72.png")
 		link(rel="apple-touch-icon", sizes="114x114", href="/images/apple-touch-icon-114x114.png")
 		link(rel="apple-touch-icon", sizes="144x144", href="/images/apple-touch-icon-144x144.png")
-		link(rel="search", href="/opensearch.xml", type="application/opensearchdescription+xml", title="Arch Linux")
+		link(rel="search", href="/static/opensearch.xml", type="application/opensearchdescription+xml", title="Arch Linux")
 		meta(name="theme-color", content="#08C")
 	body
 		div#archnavbar(class=selected)

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -23,6 +23,7 @@ html(lang="ja")
 		link(rel="apple-touch-icon", sizes="72x72", href="/images/apple-touch-icon-72x72.png")
 		link(rel="apple-touch-icon", sizes="114x114", href="/images/apple-touch-icon-114x114.png")
 		link(rel="apple-touch-icon", sizes="144x144", href="/images/apple-touch-icon-144x144.png")
+		link(rel="search", href="/opensearch.xml", type="application/opensearchdescription+xml", title="Arch Linux")
 		meta(name="theme-color", content="#08C")
 	body
 		div#archnavbar(class=selected)


### PR DESCRIPTION
これは、ブラウザのアドレスバーにてTab検索を追加する実装です。例えば、`archlinuxjp.org`と入力または補完した後に`Tab`を押すと、指定した実装で検索が可能になります。ここではパッケージを検索するようにしています。

[opensearch.org](opensearch.org)

なお、プレビューがうまく働かなかったのでプレビューはできていません。

本家では、`/opensearch/packages/`にて追加されている感じですが、こちらでは、わかりやすく`/opensearch.xml`としています。

``` html
- <link href="/opensearch/packages/" />
+ <link href="/static/opensearch.xml" />
```
