### PR TITLE
libutf8proc についてのニュース追加

### DIFF
--- a/views/news/index.sql
+++ b/views/news/index.sql
@@ -16,7 +16,7 @@ INSERT INTO
 VALUES
 	(
 		"libutf8proc211-3-update-requires-manual-intervention",
-		"libutf8proc>=2.1.1-3 update requires manual intervention",
+		"libutf8proc 2.1.1-3 以降への更新は手動での作業が必要です",
 		"2018-07-14",
 		"2018-07-14",
 		"Antonio Rojas"

--- a/views/news/index.sql
+++ b/views/news/index.sql
@@ -15,6 +15,13 @@ INSERT INTO
 	news
 VALUES
 	(
+		"libutf8proc211-3-update-requires-manual-intervention",
+		"libutf8proc>=2.1.1-3 update requires manual intervention",
+		"2018-07-14",
+		"2018-07-14",
+		"Antonio Rojas"
+	),
+	(
 		"js52-5273-2-upgrade-requires-intervention",
 		"js52 52.7.3-2 のアップグレードは手動での作業が必要です",
 		"2018-05-04",

--- a/views/news/libutf8proc211-3-update-requires-manual-intervention.html
+++ b/views/news/libutf8proc211-3-update-requires-manual-intervention.html
@@ -1,0 +1,5 @@
+<p>The libutf8proc package prior to version 2.1.1-3 had an incorrect soname link. This has been fixed in 2.1.1-3, so the upgrade will need to overwrite the untracked soname link created by ldconfig. If you get an error</p>
+<p><code>libutf8proc: /usr/lib/libutf8proc.so.2 exists in filesystem</code></p>
+<p>when updating, use</p>
+<p><code>pacman -Suy --overwrite usr/lib/libutf8proc.so.2</code></p>
+<p>to perform the upgrade.</p>

--- a/views/news/libutf8proc211-3-update-requires-manual-intervention.html
+++ b/views/news/libutf8proc211-3-update-requires-manual-intervention.html
@@ -1,5 +1,4 @@
-<p>The libutf8proc package prior to version 2.1.1-3 had an incorrect soname link. This has been fixed in 2.1.1-3, so the upgrade will need to overwrite the untracked soname link created by ldconfig. If you get an error</p>
+<p>libutf8proc 2.1.1-3 以前の libutf8proc パッケージは SONAME が正しくない <code>libutf8proc.so.2</code> を含んでいます。これは libutf8proc 2.1.1-3 で修正されたため、更新時には ldconfig により生成された追跡できない <code>libutf8proc.so.2</code> を上書きする必要があります。もし次のようなエラーが生じた場合、</p>
 <p><code>libutf8proc: /usr/lib/libutf8proc.so.2 exists in filesystem</code></p>
-<p>when updating, use</p>
+<p>更新時に次のコマンドを使用してください。</p>
 <p><code>pacman -Suy --overwrite usr/lib/libutf8proc.so.2</code></p>
-<p>to perform the upgrade.</p>

--- a/views/news/libutf8proc211-3-update-requires-manual-intervention.html
+++ b/views/news/libutf8proc211-3-update-requires-manual-intervention.html
@@ -1,4 +1,4 @@
 <p>libutf8proc 2.1.1-3 以前の libutf8proc パッケージは SONAME が正しくない <code>libutf8proc.so.2</code> を含んでいます。これは libutf8proc 2.1.1-3 で修正されたため、更新時には ldconfig により生成された追跡できない <code>libutf8proc.so.2</code> を上書きする必要があります。もし次のようなエラーが生じた場合、</p>
 <p><code>libutf8proc: /usr/lib/libutf8proc.so.2 exists in filesystem</code></p>
 <p>更新時に次のコマンドを使用してください。</p>
-<p><code>pacman -Suy --overwrite usr/lib/libutf8proc.so.2</code></p>
+<p><code>pacman -Suy --overwrite /usr/lib/libutf8proc.so.2</code></p>


### PR DESCRIPTION
ニュース `libutf8proc>=2.1.1-3 update requires manual intervention` の訳文です。
多少冗長に書いているつもりなので、たたき台としてご利用ください。