### PR TITLE
fix Resource not accessible by integration

### DIFF
--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -15,7 +15,7 @@ jobs:
       run: gem i sqlint
     - name: lint and support
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.ORIGIN_GITHUB_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         URL: ${{ github.event.pull_request.comments_url }}
         GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
github actionsに記述する`GITHUB_TOKEN`ではPRの作成者がリポジトリへのアクセス許可を持たない場合、PRコメント欄へのポストに失敗してしまうようで以下のエラーが出ています。

> Resource not accessible by integration

https://github.com/actions/first-interaction/issues/10

したがって、独自のシークレット変数を作成し、使える`GITHUB_TOKEN`を入れてみました。
