### PR TITLE
fix gh-actions pull_request_target

### DIFF
--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request:
+  pull_request_target:
     types: opened
 
 jobs:


### PR DESCRIPTION
tokenを発行し、secretに入れても読み取り権限がないようなので、新しく追加された`pull_request_target`を使用してみることにします。

https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/