### PR TITLE
Add translated news "arch-conf-2020-schedule" and "ghostpcl9532-2-and-ghostxps9532-2-updates-require-manual-intervention"

### DIFF
--- a/views/news/arch-conf-2020-schedule.html
+++ b/views/news/arch-conf-2020-schedule.html
@@ -1,0 +1,9 @@
+<p>On the 10th and 11th of October there is going to be an online edition of Arch
+Conf. The conference is going to have presentations from the Arch team along
+with community submitted presentations and lightning talks.</p>
+<p>We are proud to announce the first revision of the schedule!</p>
+<p><a href="https://pretalx.com/arch-conf-online-2020/talk/">https://pretalx.com/arch-conf-online-2020/talk/</a></p>
+<p>The conference timezone is CEST/UTC+2: <a href="https://everytimezone.com/s/40cc4784">https://everytimezone.com/s/40cc4784</a></p>
+<p>Updates and additional information can be found on the conference page: <a href="https://conf.archlinux.org">https://conf.archlinux.org</a></p>
+<p>See you there!</p>
+<p>Cheers from the conference team.</p>

--- a/views/news/arch-conf-2020-schedule.html
+++ b/views/news/arch-conf-2020-schedule.html
@@ -1,9 +1,9 @@
-<p>On the 10th and 11th of October there is going to be an online edition of Arch
-Conf. The conference is going to have presentations from the Arch team along
-with community submitted presentations and lightning talks.</p>
-<p>We are proud to announce the first revision of the schedule!</p>
+<p>10月の10日と11日に、Arch Conf のオンライン版が開催されます。
+カンファレンスでは、Arch チームからのプレゼンテーション、
+コミュニティから送信されたプレゼンテーションとライトニングトークがあります。</p>
+<p>初版のスケジュールを公表できることを嬉しく思います！</p>
 <p><a href="https://pretalx.com/arch-conf-online-2020/talk/">https://pretalx.com/arch-conf-online-2020/talk/</a></p>
-<p>The conference timezone is CEST/UTC+2: <a href="https://everytimezone.com/s/40cc4784">https://everytimezone.com/s/40cc4784</a></p>
-<p>Updates and additional information can be found on the conference page: <a href="https://conf.archlinux.org">https://conf.archlinux.org</a></p>
-<p>See you there!</p>
-<p>Cheers from the conference team.</p>
+<p>カンファレンスのタイムゾーンは CEST/UTC+2 です。 <a href="https://everytimezone.com/s/40cc4784">https://everytimezone.com/s/40cc4784</a></p>
+<p>アップデートと追加情報はカンファレンスページを見てください。 <a href="https://conf.archlinux.org">https://conf.archlinux.org</a></p>
+<p>是非参加してください！</p>
+<p>カンファレンスチームからのお知らせでした。</p>

--- a/views/news/ghostpcl9532-2-and-ghostxps9532-2-updates-require-manual-intervention.html
+++ b/views/news/ghostpcl9532-2-and-ghostxps9532-2-updates-require-manual-intervention.html
@@ -1,0 +1,11 @@
+<p>The ghostpcl and ghostxps packages prior to version 9.53.2-2 were missing
+a soname link each. This has been fixed in 9.53.2-2, so the upgrade will
+need to overwrite the untracked files created by ldconfig. If you get any
+of these errors</p>
+<pre><code>ghostpcl: /usr/lib/libgpcl6.so.9 exists in filesystem
+ghostxps: /usr/lib/libgxps.so.9 exists in filesystem
+</code></pre>
+<p>when updating, use</p>
+<pre><code>pacman -Syu --overwrite /usr/lib/libgpcl6.so.9,/usr/lib/libgxps.so.9
+</code></pre>
+<p>to perform the upgrade.</p>

--- a/views/news/ghostpcl9532-2-and-ghostxps9532-2-updates-require-manual-intervention.html
+++ b/views/news/ghostpcl9532-2-and-ghostxps9532-2-updates-require-manual-intervention.html
@@ -1,11 +1,10 @@
-<p>The ghostpcl and ghostxps packages prior to version 9.53.2-2 were missing
-a soname link each. This has been fixed in 9.53.2-2, so the upgrade will
-need to overwrite the untracked files created by ldconfig. If you get any
-of these errors</p>
+<p>バージョン 9.53.2-2 より古い ghostpcl と ghostxps パッケージはそれぞれ soname リンクが
+欠けていました。これはバージョン 9.53.2-2 で修正され、ldconfig により生成された追跡されないファイル
+を更新時に上書きする必要があります。更新時に以下のエラーが表示された場合、</p>
 <pre><code>ghostpcl: /usr/lib/libgpcl6.so.9 exists in filesystem
 ghostxps: /usr/lib/libgxps.so.9 exists in filesystem
 </code></pre>
-<p>when updating, use</p>
+<p>以下のコマンド</p>
 <pre><code>pacman -Syu --overwrite /usr/lib/libgpcl6.so.9,/usr/lib/libgxps.so.9
 </code></pre>
-<p>to perform the upgrade.</p>
+<p>を使用して更新を行ってください。</p>

--- a/views/news/index.sql
+++ b/views/news/index.sql
@@ -16,7 +16,7 @@ INSERT INTO
 VALUES
 	(
 		"arch-conf-2020-schedule",
-		"Arch Conf 2020 schedule",
+		"Arch Conf 2020 のスケジュール",
 		"2020-09-23",
 		"2020-09-23",
 		"Morten Linderud"

--- a/views/news/index.sql
+++ b/views/news/index.sql
@@ -16,7 +16,7 @@ INSERT INTO
 VALUES
 	(
 		"ghostpcl9532-2-and-ghostxps9532-2-updates-require-manual-intervention",
-		"ghostpcl>=9.53.2-2 and ghostxps>=9.53.2-2 updates require manual intervention",
+		"ghostpcl>=9.53.2-2 と ghostxps>=9.53.2-2 への更新は対応作業が必要です",
 		"2020-10-01",
 		"2020-10-01",
 		"Jan Alexander Steffens"

--- a/views/news/index.sql
+++ b/views/news/index.sql
@@ -15,6 +15,13 @@ INSERT INTO
 	news
 VALUES
 	(
+		"ghostpcl9532-2-and-ghostxps9532-2-updates-require-manual-intervention",
+		"ghostpcl>=9.53.2-2 and ghostxps>=9.53.2-2 updates require manual intervention",
+		"2020-10-01",
+		"2020-10-01",
+		"Jan Alexander Steffens"
+	),
+	(
 		"arch-conf-2020-schedule",
 		"Arch Conf 2020 のスケジュール",
 		"2020-09-23",

--- a/views/news/index.sql
+++ b/views/news/index.sql
@@ -15,6 +15,13 @@ INSERT INTO
 	news
 VALUES
 	(
+		"arch-conf-2020-schedule",
+		"Arch Conf 2020 schedule",
+		"2020-09-23",
+		"2020-09-23",
+		"Morten Linderud"
+	),
+	(
 		"kill-arch-bugs-help-us-on-the-13th-of-september",
 		"Arch のバグ対処: 9月13日に手伝ってください！",
 		"2020-09-09",


### PR DESCRIPTION
先に古い方から……。