### PR TITLE
fix gh-actions github_token

### DIFF
--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -15,7 +15,7 @@ jobs:
       run: gem i sqlint
     - name: lint and support
       env:
-        GITHUB_TOKEN: ${{ secrets.ORIGIN_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         URL: ${{ github.event.pull_request.comments_url }}
         GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
CI(lint)から投稿されるコメントが自分のアイコンになってるのでちょっと気になりました。これは個人のtokenを使用してコメントしているためです。

これを個人tokenではなくgh-actionsが用意するtokenを使用することで、アイコンを個人からgithubに変更する効果があると思われます。

ただ、以前に失敗したとおり権限周りがあまり良くわかっていないので、PRを送ってくれる人の権限によっては再びコメント投稿が失敗するかもしれません。

しかし、以前に変更した`pull_request_target`の用途から考えると、おそらく大丈夫なのではないかと思います。