### PR TITLE
Add news undone-replacement-of-pipewire-media-session-with-wireplumber

### DIFF
--- a/views/news/index.sql
+++ b/views/news/index.sql
@@ -15,6 +15,13 @@ INSERT INTO
 	news
 VALUES
 	(
+		"undone-replacement-of-pipewire-media-session-with-wireplumber",
+		"Undone replacement of pipewire-media-session with wireplumber",
+		"2022-05-12",
+		"2022-05-12",
+		"Jan Alexander Steffens"
+	),
+	(
 		"qemu-700-changes-split-package-setup",
 		"QEMU >= 7.0.0 は分割パッケージのセットアップを変更します",
 		"2022-05-09",

--- a/views/news/index.sql
+++ b/views/news/index.sql
@@ -16,7 +16,7 @@ INSERT INTO
 VALUES
 	(
 		"undone-replacement-of-pipewire-media-session-with-wireplumber",
-		"Undone replacement of pipewire-media-session with wireplumber",
+		"pipewire-media-session の wireplumber への置き換えはまだ完了していません",
 		"2022-05-12",
 		"2022-05-12",
 		"Jan Alexander Steffens"

--- a/views/news/undone-replacement-of-pipewire-media-session-with-wireplumber.html
+++ b/views/news/undone-replacement-of-pipewire-media-session-with-wireplumber.html
@@ -1,0 +1,6 @@
+<p>Two days ago the <code>wireplumber</code> package was made to replace <code>pipewire-media-session</code> as the latter session manager for PipeWire is considered dead upstream and will see no more releases. Unfortunately, this step was premature.</p>
+<p>Our pipewire audio packages (<code>pipewire-alsa</code>, <code>pipewire-jack</code> and <code>pipewire-pulse</code>) ship configuration that prompt media-session to activate PipeWire's audio features. When these packages are not installed and the configuration is missing, PipeWire can be used for screen recording without interfering with ALSA or PulseAudio.</p>
+<p>WirePlumber disregards this mechanism and always configures PipeWire to grab audio devices, meaning users of PulseAudio or bare ALSA experience broken audio.</p>
+<p>The replacement has been reverted while we attempt to look for a better solution switching to WirePlumber. If you are currently not using PipeWire for audio and <code>wireplumber</code> got installed on your system, please reinstall <code>pipewire-media-session</code> and reboot to restore audio functionality.</p>
+<pre><code>pacman -Syu pipewire-media-session
+</code></pre>

--- a/views/news/undone-replacement-of-pipewire-media-session-with-wireplumber.html
+++ b/views/news/undone-replacement-of-pipewire-media-session-with-wireplumber.html
@@ -1,6 +1,6 @@
-<p>Two days ago the <code>wireplumber</code> package was made to replace <code>pipewire-media-session</code> as the latter session manager for PipeWire is considered dead upstream and will see no more releases. Unfortunately, this step was premature.</p>
-<p>Our pipewire audio packages (<code>pipewire-alsa</code>, <code>pipewire-jack</code> and <code>pipewire-pulse</code>) ship configuration that prompt media-session to activate PipeWire's audio features. When these packages are not installed and the configuration is missing, PipeWire can be used for screen recording without interfering with ALSA or PulseAudio.</p>
-<p>WirePlumber disregards this mechanism and always configures PipeWire to grab audio devices, meaning users of PulseAudio or bare ALSA experience broken audio.</p>
-<p>The replacement has been reverted while we attempt to look for a better solution switching to WirePlumber. If you are currently not using PipeWire for audio and <code>wireplumber</code> got installed on your system, please reinstall <code>pipewire-media-session</code> and reboot to restore audio functionality.</p>
+<p>PipeWire のセッションマネージャーである <code>pipewire-media-session</code> はアップストリームで廃止され今後リリースされなくなったため、2日前に <code>wireplumber</code> パッケージにより置き換えを実施しました。残念ながら、このステップは時期尚早でした。</p>
+<p>私達の pipewire オーディオパッケージ (<code>pipewire-alsa</code>、<code>pipewire-jack</code> と <code>pipewire-pulse</code>) は、media-session に PipeWire のオーディオ機能を有効化させる設定を含んでいます。これらのパッケージがインストールされておらず設定が欠けているとき、PipeWire は ALSA や PulseAudio に干渉することなくスクリーンレコーディングに使用できます。</p>
+<p>WirePlumber はこの仕組みを無視して、常に PipeWire を使用してオーディオデバイスを扱うように設定します。これは、PulseAudio や素の ALSA のユーザーにオーディオの問題が生じることを意味します。</p>
+<p>私達が WirePlumber へ移行するよりよい方法を見つけるまで、この置き換えは差し戻されます。もし今オーディオに PipeWire を使っておらず、システムに <code>wireplumber</code> がインストールされている場合、<code>pipewire-media-session</code> をインストールし直して再起動することで、オーディオ機能を復元することができます。</p>
 <pre><code>pacman -Syu pipewire-media-session
 </code></pre>


### PR DESCRIPTION
Added this news: https://archlinux.org/news/undone-replacement-of-pipewire-media-session-with-wireplumber/