### PR TITLE
Updated package link to gitlab

### DIFF
--- a/views/package.pug
+++ b/views/package.pug
@@ -9,9 +9,9 @@ block content
 				ul.small
 					- var repo = (package["repo"] == "community" || package["repo"] == "community-testing") ? "community" : "packages";
 					- if(package["pkgbase"] != ""){
-					li <a href="https://github.com/archlinux/svntogit-!{repo}/tree/packages/#{package["pkgname"]}/trunk" title="#{package["pkgname"]} のソースファイル">#{__('sourcefile')}</a> / <a href="https://github.com/archlinux/svntogit-!{repo}/commits/packages/#{package["pkgname"]}/trunk" title="#{package["pkgname"]} の変更履歴">#{__('viewchanges')}</a>
+					li <a href="https://gitlab.com/archlinux/packaging/packages/#{package["pkgname"]}" title="#{package["pkgname"]} のソースファイル">#{__('sourcefile')}</a> / <a href="https://gitlab.com/archlinux/packaging/packages/#{package["pkgname"]}/-/commits/main" title="#{package["pkgname"]} の変更履歴">#{__('viewchanges')}</a>
 					- }else{
-					li <a href="https://github.com/archlinux/svntogit-!{repo}/tree/packages/#{package["pkgname"]}/trunk" title="#{package["pkgname"]} のソースファイル">#{__('sourcefile')}</a> / <a href="https://github.com/archlinux/svntogit-!{repo}/commits/packages/#{package["pkgname"]}/trunk" title="#{package["pkgname"]} の変更履歴">#{__('viewchanges')}</a>
+					li <a href="https://gitlab.com/archlinux/packaging/packages/#{package["pkgname"]}" title="#{package["pkgname"]} のソースファイル">#{__('sourcefile')}</a> / <a href="https://gitlab.com/archlinux/packaging/packages/#{package["pkgname"]}/-/commits/main" title="#{package["pkgname"]} の変更履歴">#{__('viewchanges')}</a>
 					- }
 					li
 						a(href=__('archwiki') + package["pkgname"], title=package["pkgname"] + " について wiki で検索") #{__('searchwiki')}


### PR DESCRIPTION
「[packageの"Source files"リンクが古いままになっている #74](https://github.com/ArchLinuxJP/archweb-jp/issues/74)」に対応しました。 

実際に動かさずにコードを編集しました。